### PR TITLE
Support one-off tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,59 @@
-
-ISP LOGGER
+# ISP Logger
 
 Thank you for your interest in ISP Logger.
-  
+
 The project is still heavily work in progress, but a basic version is working.
 
-What you need:
- 
+# What you need
 
-1) Create an account over at https://isplogger.com/
+## Prerequisites
 
-2) Create a network and obtain your Device ID. It's a UUID string.
+1. Create an account over at https://isplogger.com/
+
+2. Create a network and obtain your Device ID. It's a UUID string.
+
+3. Install Docker, or clone the project repo, then install Python 3.9+ and the project's dependencies.
 
 For simplicity, run this project on Docker, but you're also free to run the python code directly.
 
-It's been tested on MacOS and Linux. 
+It's been tested on MacOS and Linux.
+
 I'd love it if Windows users can help me out. It should work fine on Docker, but let me know if you have trouble.
-
-
-3) Pull the project from the Docker Hub Hub (Recommended): `$ docker pull ronaldl93/isp-logger `.
-
-If this is successful, time to run the container,
-
-`$ docker run -it -d -e NETWORK_ID="<the device id you obtained from the website>" ronaldl93/isp-logger`
-
- 
-A speed test will now perform once, and then again every 60 minutes.
-
-
-You can see the results on your account at ISP Logger.
 
 I highly recommend running this on a home server or computer that never sleeps / gets switched off.
 I'm using an old-ish computer, running Ubuntu Server.
 
-Something like a Raspberry Pi will work just fine as well. As long as it can run docker, you can run it on any device.
+Something like a Raspberry Pi will work just fine as well. As long as it can run Docker, you can run it.
+
+## Run in the background
+
+Pull the project from the Docker Hub (recommended):
+
+`$ docker pull ronaldl93/isp-logger`
+
+If this is successful, time to run the container:
+
+`$ docker run -it -d --restart always -e NETWORK_ID="<the device id you obtained from the website>" ronaldl93/isp-logger`
+
+A speed test will now perform once, and then again every 60 minutes. With
+Docker's `--restart always` flag, ISP Logger will automatically start on boot.
+
+## Run a one-off test
+
+ISP Logger can run a one-off speed test if e.g., you want to check changes you made to your network.
+
+You can `docker exec` into your existing Docker container and
+run the test there, or you can run the Python script natively on your host if
+you've installed the dependencies.
+
+```shell
+$ docker ps --format "{{.Image}} {{.Names}}"
+ronaldl93/isp-logger pensive_napier
+
+$ docker exec -it pensive_napier sh
+\ # python script.py --one-shot
+```
+
+# Viewing your results
+
+You can see the results in your account on ISP Logger's website, https://isplogger.com/.

--- a/script.py
+++ b/script.py
@@ -21,10 +21,12 @@ logger = logging.getLogger(__name__)
 load_dotenv()
 
 key = os.environ.get("NETWORK_ID", False)
+if not key:
+    key = input("Enter the network key, obtained from the ISP Logger dashboard:\t")
+
 server = "https://api.isplogger.com"
 
 def initSpeedtest():
-    # key = os.environ.get("NETWORK_ID")
     print("Speedtest in Progress")
     s = speedtest.Speedtest()
     s.get_servers()
@@ -49,7 +51,6 @@ def initSpeedtest():
 @sched.scheduled_job('interval', minutes=60)
 def test():
     attempts = 10
-    key = os.environ.get("NETWORK_ID")
     for i in range(attempts):
 
         try:
@@ -68,13 +69,6 @@ def test():
                 raise
         break
 
-if key is not False:
-    test()
-    if len(sys.argv) == 1 or sys.argv[1] != "--one-shot":
-        sched.start()
-else:
-    net_key = input("Enter the network key, obtained from the ISP Logger dashboard:  ")
-    os.environ["NETWORK_ID"] = str(net_key)
-    # print(net_key)
-    test()
+test()
+if len(sys.argv) == 1 or sys.argv[1] != "--one-shot":
     sched.start()

--- a/script.py
+++ b/script.py
@@ -7,6 +7,7 @@ import os
 from apscheduler.schedulers.blocking import BlockingScheduler
 import logging
 import ssl
+import sys
 ssl._create_default_https_context = ssl._create_unverified_context
 
 sched = BlockingScheduler()
@@ -50,7 +51,7 @@ def test():
     attempts = 10
     key = os.environ.get("NETWORK_ID")
     for i in range(attempts):
-    
+
         try:
 
             tst = initSpeedtest()
@@ -69,7 +70,8 @@ def test():
 
 if key is not False:
     test()
-    sched.start()
+    if len(sys.argv) == 1 or sys.argv[1] != "--one-shot":
+        sched.start()
 else:
     net_key = input("Enter the network key, obtained from the ISP Logger dashboard:  ")
     os.environ["NETWORK_ID"] = str(net_key)


### PR DESCRIPTION
Add support for running one-off tests without starting the scheduler. Update the docs to reflect that. DRY up the script in the process.