### PR TITLE
Native PI3 Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-alpine
+FROM balenalib/raspberrypi3-python:latest
 
 ADD script.py .
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+Note: This changes the docker base image to be Pi3 compatible. All other functions remain unchanged.
+Forked from ronaldlangeveld/isplogger_server
+
+
+ORIGINAL RELEASE NOTES:
 
 ISP LOGGER
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,13 +6,13 @@ idna==2.10
 isort==5.6.4
 lazy-object-proxy==1.4.3
 mccabe==0.6.1
-pylint==2.8.3
+pylint==2.6.0
 python-dotenv==0.15.0
 pytz==2020.5
 requests==2.25.1
 six==1.15.0
-speedtest-cli==2.1.2
+speedtest-cli==2.1.3
 toml==0.10.2
 tzlocal==2.1
-urllib3==1.26.5
+urllib3==1.26.2
 wrapt==1.12.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ idna==2.10
 isort==5.6.4
 lazy-object-proxy==1.4.3
 mccabe==0.6.1
-pylint==2.6.0
+pylint==2.8.3
 python-dotenv==0.15.0
 pytz==2020.5
 requests==2.25.1
@@ -14,5 +14,5 @@ six==1.15.0
 speedtest-cli==2.1.2
 toml==0.10.2
 tzlocal==2.1
-urllib3==1.26.2
+urllib3==1.26.5
 wrapt==1.12.1


### PR DESCRIPTION
This change is to provide a dockerfile that is compatible with older Pi3 models